### PR TITLE
Updates all user test based on feedback

### DIFF
--- a/app/actions/user.action.js
+++ b/app/actions/user.action.js
@@ -76,8 +76,8 @@ export function LOGIN(req, res) {
      .then((user) => {
        if (user) {
          if (body.password !== verifyPassword(user.password)) {
-           return res.status(403).json({
-             status: 403,
+           return res.status(400).json({
+             status: 400,
              message: 'Authenication failed. Username or password is incorrect',
            });
          }
@@ -92,8 +92,8 @@ export function LOGIN(req, res) {
            token,
          });
        }
-       return res.status(403).json({
-         status: 403,
+       return res.status(400).json({
+         status: 400,
          message: 'Authenication failed. Username or password is incorrect',
        });
      });

--- a/tests/server/2-user.spec.js
+++ b/tests/server/2-user.spec.js
@@ -71,7 +71,7 @@ describe('User', () => {
         .post('/api/users/login')
         .send(userSeed[5])
         .end((err, res) => {
-            res.status.should.equal(403);
+            res.status.should.equal(400);
             res.body.message.should.equal('Authenication failed. Username or password is incorrect');
             done();
         })
@@ -82,7 +82,7 @@ describe('User', () => {
         .post('/api/users/login')
         .send(userSeed[6])
         .end((err, res) => {
-            res.status.should.equal(403);
+            res.status.should.equal(400);
             res.body.message.should.equal('Authenication failed. Username or password is incorrect');
             done();
         })
@@ -105,6 +105,17 @@ describe('User', () => {
         .end((err, res) => {
             res.status.should.equal(200);
             res.body.length.should.be.above(0);
+            done();
+        });
+  });
+
+  it('should return an error if non-admin users try to request all users', (done) => {
+      server
+        .get('/api/users')
+        .set('authorization', userToken)
+        .end((err, res) => {
+            res.status.should.equal(403);
+            res.body.message.should.equal('You are not authorized to view this content');
             done();
         });
   });
@@ -216,7 +227,7 @@ describe('User', () => {
         });
   });
 
-  it('should return all documents for the user if admin', (done) => {
+  it('should return all documents(private, public) for the user if admin', (done) => {
       server
         .get('/api/users/2/documents')
         .set('authorization', adminToken)
@@ -235,7 +246,7 @@ describe('User', () => {
         });
   });
 
-  it('should return all documents if regular user queries for documents', (done) => {
+  it('should return all documents(public, private documents created by same user) if regular user queries for documents', (done) => {
       server
         .get('/api/users/2/documents')
         .set('authorization', diffToken)


### PR DESCRIPTION
This PR resolves all issues stated below

**For User tests:**

-  `it('should return all documents if regular user queries for documents')`
>This description is not accurate as it does not indicate that it's referring to users other than the creator of the documents
>It should test that only `public` documents are returned for users other than the creator as opposed to all docs like you have done there

-  `it('should validate that only admins get to request all users')`
>This does not also assert that regular user tokens get a different result

-  `it('should return error if login password is wrong')`
>This has inappropriate error codes

-  ` it('should return error if login user not found')`
>This has inappropriate error codes
