### PR TITLE
Updates roles test based on feedback

### DIFF
--- a/app/routes/role.route.js
+++ b/app/routes/role.route.js
@@ -3,11 +3,8 @@ import { adminAccess, authorization } from '../controllers/auth.controller';
 
 const roleRoute = (router) => {
   router
-    .route('/roles/create')
-    .post(authorization, adminAccess, roleControl.create);
-
-  router
     .route('/roles')
+    .post(authorization, adminAccess, roleControl.create)
     .get(authorization, adminAccess, roleControl.getAll);
 };
 

--- a/tests/server/1-roles.spec.js
+++ b/tests/server/1-roles.spec.js
@@ -15,7 +15,7 @@ const wrongToken = 'wrong';
 describe('Role', () => {
     it('should create a new role', (done) => {
         server
-          .post('/api/roles/create')
+          .post('/api/roles')
           .send(roleSeed[0])
           .set('authorization', adminToken)
           .end((err, res) => {
@@ -27,7 +27,7 @@ describe('Role', () => {
 
     it('should return err if role title is not set', (done) => {
         server
-          .post('/api/roles/create')
+          .post('/api/roles')
           .set('authorization', adminToken)
           .end((err, res) => {
              res.status.should.equal(400);
@@ -38,7 +38,7 @@ describe('Role', () => {
 
     it('should return err if role is created twice', (done) => {
         server
-          .post('/api/roles/create')
+          .post('/api/roles')
           .send(roleSeed[0])
           .set('authorization', adminToken)
           .end((err, res) => {
@@ -65,7 +65,7 @@ describe('Role', () => {
 
     it('should return err if wrong route is sent', (done) => {
         server
-          .post('/api/roles')
+          .post('/api/roles/create')
           .set('authorization', adminToken)
           .end((err, res) => {
               res.status.should.equal(404);


### PR DESCRIPTION
This PR resolves all issues stated below

**For the Role tests**

-  Routes should be thought off as resources with which when called with different methods, cause different actions. Hence `POST api/roles` should be the route to create new roles NOT `POST api/roles/create`, with `roles` being the resource in this case.

-  Based on :point_up: , `it('should return err if wrong route is sent')` does not make complete sense, and would need to be refactored for it to be relevant.