### PR TITLE
Updates document test based on feedback

### DIFF
--- a/app/actions/document.action.js
+++ b/app/actions/document.action.js
@@ -60,7 +60,7 @@ export function GETALL(req, res) {
   Document
     .findAll(filter)
     .then((documents) => {
-      if (req.decoded.role === 'regular' || req.query.role && req.query.role !== 'admin') { 
+      if (req.decoded.role === 'regular' || req.query.role && req.query.role !== 'admin') {
         const docs = documents.filter((document) => {
           const docArr = [];
           if (document.owner === req.decoded.username && document.type === 'public') {
@@ -79,9 +79,9 @@ export function GETALL(req, res) {
       if (req.decoded.role === 'admin') {
         return res.status(200).json(documents);
       }
-      return res.status(509).json({
-        status: 509,
-        message: 'Server error',
+      return res.status(400).json({
+        status: 400,
+        message: 'Authentication failed: You are not a valid user',
       });
     });
 }
@@ -121,8 +121,8 @@ export function UPDATE(req, res) {
     .findOne(filter)
     .then((document) => {
       if (!document) {
-        return res.status(400).json({
-          status: 400,
+        return res.status(404).json({
+          status: 404,
           message: 'Document not found',
         });
       }

--- a/tests/server/3-document.spec.js
+++ b/tests/server/3-document.spec.js
@@ -71,13 +71,13 @@ describe('Document', () => {
           });
     });
 
-    it('should return err if something goes wrong with the server', (done) => {
+    it('should return err if something goes wrongtoken is used for accessing all documents', (done) => {
         server
            .get('/api/documents')
            .set('authorization', wrongToken)
            .end((err, res) => {
-               res.status.should.equal(509);
-               res.body.message.should.equal('Server error');
+               res.status.should.equal(400);
+               res.body.message.should.equal('Authentication failed: You are not a valid user');
                done();
            });
     })
@@ -100,7 +100,13 @@ describe('Document', () => {
           .set('authorization', adminToken)
           .end((err, res) => {
               res.status.should.equal(200);
-              res.body[1].should.have.value('role', 'regular');
+              for(let i=0; i<res.body.length; i++) {
+                  if (res.body[i].role === 'admin') {
+                    res.body[i].should.have.value('role', 'admin',);
+                  } else {
+                    res.body[i].should.have.value('role', 'regular',);
+                  }
+              }
               done();
           });
     });
@@ -116,6 +122,7 @@ describe('Document', () => {
                 .set('authorization', adminToken)
                 .end((err, res) => {
                     res.status.should.equal(200);
+                    res.body[0].createdAt.should.equal(date);
                     res.body.length.should.be.equal(1);
                     done();
                 });
@@ -128,6 +135,7 @@ describe('Document', () => {
         .set('authorization', adminToken)
         .end((err, res) => {
             res.status.should.equal(200)
+            res.body[0].id.should.equal(5);
             res.body.length.should.equal(1);
             done();
         });
@@ -162,7 +170,7 @@ describe('Document', () => {
           .send({ title: 'Wrong ways'})
           .set('authorization', userToken)
           .end((err, res) => {
-              res.status.should.equal(400);
+              res.status.should.equal(404);
               res.body.message.should.equal('Document not found');
               done();
           });


### PR DESCRIPTION
This PR resolves all issues stated below

**For Document Tests**

-  `it('should return err if something goes wrong with the server')` is a false positive as you did not simulate a server error in it's implementation but you instead sent a wrong token, which is an authentication issue, client side error.

-  `it('should return result if role query is used')` should loop through all results to assert that all items have the expected role.

-  `it('should return based on date created')` should instead be testing that the date of the result is the same as the date sent in the query

-  `it('should return a document if queried by its ID')` should also test that the document ID is in fact 5

-  `it('should return err if document is not found')` has an inappropriate status code.
